### PR TITLE
fix: remove deprecated passHref prop from Next.js Link components

### DIFF
--- a/app/_components/BlogPostItem.tsx
+++ b/app/_components/BlogPostItem.tsx
@@ -14,7 +14,7 @@ export const BlogPostItem = ({ post }: Props) => {
   };
 
   return (
-    <Link href={`/${post.id}`} passHref={true} prefetch={false}>
+    <Link href={`/${post.id}`} prefetch={false}>
       <div className="hover:cursor-pointer">
         <Image
           src={`${post.image.url}?fit=scale&w=${imageSize.width}&h=${imageSize.height}`}

--- a/app/_components/HeaderBar.tsx
+++ b/app/_components/HeaderBar.tsx
@@ -21,7 +21,7 @@ export const HeaderBar = ({ type = 'blog' }: Props) => {
       <nav>
         <ul className="list-none flex gap-4">
           <li>
-            <Link href="/" passHref={true} prefetch={false}>
+            <Link href="/" prefetch={false}>
               Blog
             </Link>
           </li>


### PR DESCRIPTION
## Summary
• Remove deprecated `passHref={true}` prop from Next.js Link components
• Update HeaderBar and BlogPostItem components to use current Next.js 13+ patterns
• Fix deprecation warnings without breaking functionality

## Test plan
- [x] Lint checks pass (oxlint)
- [x] Build succeeds with no type errors
- [x] All existing functionality preserved
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)